### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Major.Minor version (e.g., "2.0")'
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ github.event.inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Validate version format
+        run: |
+          VERSION="${{ inputs.version }}"
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid version format. Expected 'major.minor' (e.g., '2.0'), got '$VERSION'"
+            exit 1
+          fi
+          echo "Version format is valid: $VERSION"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch all tags
+        run: git fetch --tags
+
+      - name: Calculate next patch version
+        id: version
+        run: |
+          MAJOR_MINOR="${{ inputs.version }}"
+          LATEST_PATCH=$(git tag -l "v${MAJOR_MINOR}.*" | sed "s/v${MAJOR_MINOR}\.//" | sort -n | tail -1)
+          if [ -z "$LATEST_PATCH" ]; then
+            NEXT_PATCH=0
+          else
+            NEXT_PATCH=$((LATEST_PATCH + 1))
+          fi
+          FULL_VERSION="${MAJOR_MINOR}.${NEXT_PATCH}"
+          echo "version=${FULL_VERSION}" >> $GITHUB_OUTPUT
+          echo "Releasing v${FULL_VERSION}"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create version tag
+        run: |
+          git tag "v${{ steps.version.outputs.version }}" -m "Release v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"
+
+      - name: Move floating major tag
+        run: |
+          MAJOR=$(echo "${{ inputs.version }}" | cut -d. -f1)
+          git tag -f "v${MAJOR}" -m "Release v${{ steps.version.outputs.version }}"
+          git push origin "v${MAJOR}" --force
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --title "v${{ steps.version.outputs.version }}" \
+            --generate-notes

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Init and run scan action
-        uses: Traceableai/ast-action@main
+        uses: ./
         with:
           step_name: 'init and run'
           client_scan_token: ${{ secrets.CLIENT_SCAN_TOKEN_DEMO }}
@@ -23,7 +23,7 @@ jobs:
           traceable_server: ${{ secrets.TRACEABLE_SERVER_DEMO }}
       - name: Stop Scan
         if: always()
-        uses: Traceableai/ast-action@main
+        uses: ./
         with:
           step_name: 'stop'
           client_scan_token: ${{ secrets.CLIENT_SCAN_TOKEN_DEMO }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   InitAndRunAstScan:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -30,7 +30,7 @@ jobs:
           traffic_env: 'crapi-demo1'
           traceable_server: ${{ secrets.TRACEABLE_SERVER_DEMO }}
   functionalTest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Run a loop as functional test
         run: |

--- a/.github/workflows/test-traceable-ast-init-and-run.yml
+++ b/.github/workflows/test-traceable-ast-init-and-run.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Init and run scan action
-        uses: Traceableai/ast-action@main
+        uses: ./
         with:
           step_name: 'init and run'
           client_scan_token: ${{ secrets.CLIENT_SCAN_TOKEN_DEMO }}
@@ -22,7 +22,7 @@ jobs:
           traceable_server: ${{ secrets.TRACEABLE_SERVER_DEMO }}
       - name: Stop Scan
         if: always()
-        uses: Traceableai/ast-action@main
+        uses: ./
         with:
           step_name: 'stop'
           client_scan_token: ${{ secrets.CLIENT_SCAN_TOKEN_DEMO }}

--- a/.github/workflows/test-traceable-ast-init-and-run.yml
+++ b/.github/workflows/test-traceable-ast-init-and-run.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   InitAndRunAstScan:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
           traffic_env: 'crapi-demo1'
           traceable_server: ${{ secrets.TRACEABLE_SERVER_DEMO }}
   functionalTest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Run a loop as functional test
         run: |

--- a/.github/workflows/test-traceable-ast-init-traceable-ast-run.yml
+++ b/.github/workflows/test-traceable-ast-init-traceable-ast-run.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   AstScan:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test-traceable-ast-init-traceable-ast-run.yml
+++ b/.github/workflows/test-traceable-ast-init-traceable-ast-run.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Init scan action
-        uses: Traceableai/ast-action@main
+        uses: ./
         with:
           step_name: 'init'
           client_scan_token: ${{ secrets.CLIENT_SCAN_TOKEN }}
@@ -26,14 +26,14 @@ jobs:
              echo $i
           done
       - name: Run scan action
-        uses: Traceableai/ast-action@main
+        uses: ./
         with:
           step_name: 'run'
           client_scan_token: ${{ secrets.CLIENT_SCAN_TOKEN }}
           traffic_env: 'samarth-crapi'
           cli_version: 'latest'
       - name: Abort Scan
-        uses: Traceableai/ast-action@main
+        uses: ./
         if: always()
         with:
           step_name: 'stop'


### PR DESCRIPTION
## Summary
- Adds a manual `workflow_dispatch` release workflow
- Input: major.minor version (e.g., `2.0`)
- Auto-calculates the next patch version from existing tags
- Creates a semver tag, moves the floating major tag (`v2`), and publishes a GitHub Release with auto-generated notes

## Usage
Trigger from Actions tab or CLI:
```
gh workflow run release.yml -f version=1.0
```

## Test plan
- [ ] Merge and trigger with `1.0` — should create `v1.0.0` tag and `v1` floating tag
- [ ] Trigger again with `1.0` — should create `v1.0.1` and move `v1` forward